### PR TITLE
Disable harden-dnssec-stripped

### DIFF
--- a/docker/unbound.sh
+++ b/docker/unbound.sh
@@ -171,7 +171,7 @@ server:
     # Require DNSSEC data for trust-anchored zones, if such data is absent, the
     # zone becomes bogus. If turned off you run the risk of a downgrade attack
     # that disables security for a zone.
-    harden-dnssec-stripped: yes
+    harden-dnssec-stripped: no
 
     # Only trust glue if it is within the servers authority.
     harden-glue: yes


### PR DESCRIPTION
When this option is set to yes, forwarding to Amazon Route 53 Resolver does not work because of validation error.
